### PR TITLE
Fixed searching preview files

### DIFF
--- a/src/file_processing.rs
+++ b/src/file_processing.rs
@@ -50,7 +50,7 @@ pub fn get_immich_preview_files(immich_root: &Path) -> Result<Vec<PathBuf>, Imag
                         stack.push(path);
                     } else if path.is_file()
                         && let Some(filename) = path.file_name().and_then(|f| f.to_str())
-                        && filename.contains("_preview.")
+                        && (filename.contains("_preview.") || filename.contains("-preview."))
                     {
                         preview_files.push(path);
                     }


### PR DESCRIPTION
Hi, I tried running immich-analyze locally, but it didn't work because the binary couldn't find the preview files. The issue turned out to be this line—it wasn't matching the part in the filename that looked like this: "-preview." I changed it to "_preview." and everything worked.
System: macOS Sequoia, Immich is running in Docker.