### PR TITLE
fix: accept Immich's -1 rating for rejected assets

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -233,7 +233,7 @@ pub async fn get_asset_metadata(
             )
         });
         let rating = rating_raw.and_then(|value| {
-            u8::try_from(value).map_or_else(
+            i8::try_from(value).map_or_else(
                 |_| {
                     debug!("Invalid rating value for asset {asset_id}: {value}");
                     None

--- a/src/immich_api.rs
+++ b/src/immich_api.rs
@@ -70,7 +70,7 @@ pub struct ExifInfo {
     #[serde(default)]
     pub iso: Option<u32>,
     #[serde(default)]
-    pub rating: Option<u8>,
+    pub rating: Option<i8>,
     #[serde(default)]
     pub time_zone: Option<String>,
 }

--- a/src/prompt_enricher.rs
+++ b/src/prompt_enricher.rs
@@ -15,7 +15,7 @@ pub struct PromptContext {
     pub f_number: Option<f64>,
     pub focal_length: Option<f64>,
     pub iso: Option<u32>,
-    pub rating: Option<u8>,
+    pub rating: Option<i8>,
     pub time_zone: Option<String>,
     pub original_file_name: Option<String>,
     pub asset_type: Option<String>,
@@ -92,7 +92,7 @@ impl PromptContext {
         self
     }
 
-    pub const fn with_rating(mut self, rating: Option<u8>) -> Self {
+    pub const fn with_rating(mut self, rating: Option<i8>) -> Self {
         self.rating = rating;
         self
     }


### PR DESCRIPTION
Fair warning - I do not "speak" rust at all - this is entirely the result of me shouting at a piece of software until it stopped running down false leads.

The issue was that the docker container would just throw most unhelpful errors about bad json, in the curse of trying to figure out why I involved a llm model that (eventually) figured out what was wrong.

Basically you have been using unsigned for ratings which means -1 (rejected) got ignored, I am not sure why this hasn't been an issue earlier maybe base immich doesn't use it - I'm fairly sure the reason why I had it occur is due to xmp sidecar files from darktable. 

I rebuild the image to make sure it working, and it is - with the caveat that I only use API - so the db fix may or may not work at all.

This is what the software had to "say" about the fix:
---
ExifInfo::rating is typed Option<u8>, but Immich's rating range is -1 to 5, where -1 means rejected.

API mode: serde fails on the first -1, and since /api/search/metadata is fetched 1000 assets at a time, the whole page is lost. Both batch and monitor mode die with JSON parsing error for assets_list. Two rejected assets in a ~13,000-asset library made API mode entirely unusable.

Database mode: database.rs:235 already guards with u8::try_from, so it logs "Invalid rating value" and returns None — no crash, but the rating is silently discarded.

u8 → i8 in immich_api.rs, prompt_enricher.rs, and the try_from in database.rs fixes both. Happy to use i16 instead if you'd prefer headroom or a closer match to Postgres smallint.

Tested with a local Docker build against Immich v3.0.3 — full library now processes without errors.

Separately: immich_api.rs calls err.to_string() on the reqwest error, which discards the serde .source(). That message names the field and offset; without it this took a MITM proxy and a page-by-page type audit to locate. Worth logging in a follow-up.

